### PR TITLE
Require old version of urllib3 until we upgrade IRIDL squid

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cptdl
-  version: "1.1.0"
+  version: "1.1.1"
 
 source:
   path: ..

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,12 @@ requirements:
     - cptio
     - requests
 
+    # requests depends on urllib3; urllib3 v2 removes all the old,
+    # unsafe ciphers that are currently supported by the ancient
+    # version of squid on iridl.ldeo.columbia.edu, causing all https
+    # downloads to fail.
+    - urllib3<2
+
 test:
   imports:
     - cptdl

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(Path(__file__ ).parent / 'README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name="cptdl",
-    version="1.1.0",
+    version="1.1.1",
     author="Kyle Hall",
     author_email="pycpt-help@iri.columbia.edu",
     description=(

--- a/src/cptdl/__init__.py
+++ b/src/cptdl/__init__.py
@@ -4,5 +4,5 @@ from .targetleadconv import *
 
 
 __author__ = 'Kyle J. C. Hall (pycpt-help@iri.columbia.edu)'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __license__ = 'MIT'


### PR DESCRIPTION
Sylwia reported that recreating her conda environment caused DL downloads to stop working. The culprit is a recent release of urllib3 that eliminates all the old SSL ciphers that the IRIDL squid supports. To work around this until we manage to upgrade squid, pinning urllib3 to versions prior to 2.0.